### PR TITLE
modified signing certificate configuration in install_test_certificate.sh, so that it contains localhost and 127.0.0.1 as one of the Subject Alternate Names

### DIFF
--- a/src/test/sh/install_test_certificate.sh
+++ b/src/test/sh/install_test_certificate.sh
@@ -28,9 +28,16 @@ openssl genrsa -out server.key 4096
 openssl req -new -nodes -key server.key -sha256 -out server.csr -subj '/CN=ITest Exasol Server/C=DE/O=ITest'
 
 # Create certificate extensions configuration:
-echo '[extensions]
+cat > server_cert_extensions.cfg <<EOL
+[extensions]
 keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment, keyAgreement
-basicConstraints = CA:false' > server_cert_extensions.cfg
+basicConstraints = CA:false
+subjectAltName = @alt_names
+
+[alt_names]
+DNS.1 = localhost
+IP.1 = 127.0.0.1
+EOL
 
 # Sign the request:
 openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out server.crt -days 90 -sha256 -extfile server_cert_extensions.cfg -extensions extensions --passin "pass:$testpw"


### PR DESCRIPTION
- modified signing certificate configuration in [install_test_certificate.sh](https://github.com/exasol/exasol-virtual-schema-lua/pull/54/files#diff-94fcd86bf11bc93da048668c473bd2293f3e1f98441108f7ff3c68dd47704bcc), so that it contains localhost and 127.0.0.1 as one of the Subject Alternate Names